### PR TITLE
Fix runOn's

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/playercore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/playercore.lua
@@ -492,7 +492,7 @@ hook.Add("PlayerSpawn","PlyCore_PlayerSpawn", function(ply)
     lastspawnedplayer = ply
 
     for e2 in pairs(registered_e2s_spawn) do
-        if IsValid( e2:IsValid() ) then
+        if IsValid( e2 ) then
             e2:Execute()
         else
             registered_e2s_spawn[e2] = nil
@@ -534,7 +534,7 @@ hook.Add("PlayerDeath", "PlyCore_PlayerDeath", function(victim, inflictor, attac
 
     for e2 in pairs(registered_e2s_death) do
         if IsValid( e2 ) then
-            entity:Execute()
+            e2:Execute()
         else
             registered_e2s_death[e2] = nil
         end
@@ -583,7 +583,7 @@ hook.Add("PlayerInitialSpawn","PlyCore_PlayerInitialSpawn", function(ply)
 
     for e2 in pairs(registered_e2s_connect) do
         if IsValid( e2 ) then
-            entity:Execute()
+            e2:Execute()
         else
             registered_e2s_connect[e2] = nil
         end
@@ -624,7 +624,7 @@ hook.Add("PlayerDisconnected","PlyCore_PlayerDisconnected", function(ply)
 
     for e2 in pairs(registered_e2s_disconnect) do
         if IsValid( e2 ) then
-            entity:Execute()
+            e2:Execute()
         else
             registered_e2s_disconnect[e2] = nil
         end


### PR DESCRIPTION
Currently the following functions are broken and cause either errors or game breaking bugs.
```
runOnDeath(1)
runOnSpawn(1)
runOnDisconnect(1)
runOnConnect(1)
```
This pr fixes them.

Tested and works ofc.