### PR TITLE
Fix-cl-error

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/cl_playercore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_playercore.lua
@@ -22,13 +22,15 @@ E2Helper.Descriptions["plyGetSpeed"] = "Gets the speed of the player."
 local plys = {}
 net.Receive("wire_expression2_playercore_sendmessage", function( len, ply )
     local ply = net.ReadEntity()
+    if not IsValid( ply ) then return end
+
     if ply and not plys[ply] then
-    plys[ply] = true
-    -- printColorDriver is used for the first time on us by this chip
-    WireLib.AddNotify(msg1, NOTIFY_GENERIC, 7, NOTIFYSOUND_DRIP3)
-    WireLib.AddNotify(msg2, NOTIFY_GENERIC, 7)
-    chat.AddText(Color(255, 50, 50),"After this message, ", ply, " can send you a 100% realistically fake people talking, including admins.")
-    chat.AddText(Color(255, 50, 50),"Look the console to see if the message is form an expression2")
+        plys[ply] = true
+        -- printColorDriver is used for the first time on us by this chip
+        WireLib.AddNotify(msg1, NOTIFY_GENERIC, 7, NOTIFYSOUND_DRIP3)
+        WireLib.AddNotify(msg2, NOTIFY_GENERIC, 7)
+        chat.AddText(Color(255, 50, 50),"After this message, ", ply, " can send you a 100% realistically fake people talking, including admins.")
+        chat.AddText(Color(255, 50, 50),"Look the console to see if the message is form an expression2")
     end
 
     LocalPlayer():PrintMessage(HUD_PRINTCONSOLE, "[E2] " .. ply:Name() .. ": ")

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_playercore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_playercore.lua
@@ -30,7 +30,7 @@ net.Receive("wire_expression2_playercore_sendmessage", function( len, ply )
         WireLib.AddNotify(msg1, NOTIFY_GENERIC, 7, NOTIFYSOUND_DRIP3)
         WireLib.AddNotify(msg2, NOTIFY_GENERIC, 7)
         chat.AddText(Color(255, 50, 50),"After this message, ", ply, " can send you a 100% realistically fake people talking, including admins.")
-        chat.AddText(Color(255, 50, 50),"Look the console to see if the message is form an expression2")
+        chat.AddText(Color(255, 50, 50),"Look the console to see if the message is from an expression2")
     end
 
     LocalPlayer():PrintMessage(HUD_PRINTCONSOLE, "[E2] " .. ply:Name() .. ": ")


### PR DESCRIPTION
Fixes:
```
addons/cfc_playercore/lua/entities/gmod_wire_expression2/core/custom/cl_playercore.lua:34: attempt to call method 'Name' (a nil value)
  1. func - addons/cfc_playercore/lua/entities/gmod_wire_expression2/core/custom/cl_playercore.lua:34
   2. unknown - lua/includes/extensions/net.lua:33
   0.  func - addons/cfc_playercore/lua/entities/gmod_wire_expression2/core/custom/cl_playercore.lua:34
    1.  unknown - lua/includes/extensions/net.lua:33
```

If a player that calls prints leaves while the net message is queued up it will error as the player is now a NULL object.